### PR TITLE
fix: startup run waiting for db

### DIFF
--- a/mobkoitask/config.py
+++ b/mobkoitask/config.py
@@ -26,6 +26,7 @@ db_config = {
   'user': 'postgres',
   'password': 'password',
   'dbname': 'mobkoi',
+  'connection_retries': 3
 }
 
 strategies = [

--- a/mobkoitask/db/postgres.py
+++ b/mobkoitask/db/postgres.py
@@ -1,7 +1,20 @@
 import psycopg2
 
-def get_connection(host='localhost', user='postgres', password='p0stgr3s', dbname='mobkoi'):
-  return psycopg2.connect(host=host, user=user, password=password, dbname=dbname)
+def get_connection(host='localhost', user='postgres', password='p0stgr3s', dbname='mobkoi', retries=3):
+  conn = None
+  retry_counter = 0
+  while retry_counter < retries:
+    try:
+      conn = psycopg2.connect(host=host, user=user, password=password, dbname=dbname)
+    except psycopg2.OperationalError:
+      continue
+    break;
+
+  if retry_counter == retries:
+    raise psycopg2.OperationalError
+  else:
+    return conn
+
 
 def persist_exchange_rates(conn, rows):
   stmt = """


### PR DESCRIPTION
Due to an issue with the way containers are created with `docker-compose`, in this case the application starts and try to connect to the database went the database container is not yet up, then the application crashes in startup. To avoid this one we retry up until a number of times set in configuration.

There are solutions for this as outlined at https://docs.docker.com/compose/startup-order/, but preferred to use and straight but ugly patch right now and be able to refactor this operational issue properly later.